### PR TITLE
Add INCUNA_AUTH_LOGIN_FORM setting

### DIFF
--- a/incuna_auth/forms.py
+++ b/incuna_auth/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+from django.contrib.auth.forms import AuthenticationForm
+from django.utils.translation import ugettext_lazy as _
+
+
+class IncunaAuthenticationForm(AuthenticationForm):
+    username = forms.CharField(label=_('Email'), max_length=320)

--- a/incuna_auth/urls.py
+++ b/incuna_auth/urls.py
@@ -1,17 +1,14 @@
-from django import forms
+from django.conf import settings
 from django.conf.urls.defaults import patterns, url
 from django.core.urlresolvers import reverse_lazy
-from django.contrib.auth.forms import AuthenticationForm
-from django.utils.translation import ugettext_lazy as _
 from django.views.generic import RedirectView
 
 
-class IncunaAuthenticationForm(AuthenticationForm):
-    username = forms.CharField(label=_('Email'), max_length=320)
-
+auth_form_name = settings.get('INCUNA_AUTH_LOGIN_FORM', 'incuna_auth.forms.IncunaAuthenticationForm')
+auth_form = __import__(auth_form_name)
 
 urlpatterns = patterns('django.contrib.auth.views',
-    url(r'^login/$', 'login', {'authentication_form': IncunaAuthenticationForm}, name='auth_login'),
+    url(r'^login/$', 'login', {'authentication_form': auth_form}, name='auth_login'),
     url(r'^logout/$', 'logout', {'template_name': 'registration/logout.html'}, name='auth_logout'),
     # Change password (when logged in)
     url(r'^password/change/$', 'password_change', name='auth_password_change'),
@@ -23,4 +20,3 @@ urlpatterns = patterns('django.contrib.auth.views',
     url(r'^password/reset/complete/$', 'password_reset_complete', name='auth_password_reset_complete'),
     url(r'^sso/$', RedirectView.as_view(url=reverse_lazy('admin:admin_sso_openiduser_start')), name='sso_login'),
 )
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = ('django-admin-sso',)
 
 setup(
     name='incuna-auth',
-    version='0.6.1',
+    version='0.6.2',
     url='http://github.com/incuna/incuna-auth',
     packages=find_packages(),
     include_package_data=True,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -36,4 +36,3 @@ class TestLoginRequiredMiddleware(TestCase):
         response = self.middleware.process_request(self.request)
         assert False
         assert_equals(response, None)
-


### PR DESCRIPTION
The setting will be used to specify what form to use for the login (in incuna_auth.urls). 

The default would be the current form in incuna_auth.urls,IncunaAuthenticationForm. This form should be moved to incuna_auth.forms, making the default incuna_auth.forms.IncunaAuthenticationForm.
