### PR TITLE
Specify type=email on username field.

### DIFF
--- a/incuna_auth/forms.py
+++ b/incuna_auth/forms.py
@@ -16,5 +16,5 @@ class CrispyPasswordResetForm(PasswordResetForm):
 
 
 class IncunaAuthenticationForm(AuthenticationForm):
-    username = forms.CharField(label=_('Email'), max_length=320)
+    username = forms.CharField(label=_('Email'), max_length=320, widget=forms.TextInput(attrs={'type': 'email'}))
 


### PR DESCRIPTION
It would be nice to use EmailField with the EmailInput widget, but it
seems to be Django 1.6+

cc @maxpeterson @mjtamlyn (related to a incuna/patientpathways#367)
