### PR TITLE
Use Page.objects.best_match_for_path() to find Pages

### DIFF
--- a/incuna_auth/middleware/login_required_feincms.py
+++ b/incuna_auth/middleware/login_required_feincms.py
@@ -1,27 +1,5 @@
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-
-from .permission import FeinCMSPermissionMiddleware, LoginPermissionMiddlewareMixin
-
-
-def check_feincms_page():
-    """
-    Check that FeinCMSLoginRequiredMiddleware isn't being used without its dependency.
-
-    FeinCMSLoginRequiredMiddleware needs feincms.context_processors.add_page_if_missing.
-    """
-    processors = settings.TEMPLATE_CONTEXT_PROCESSORS
-
-    if 'feincms.context_processors.add_page_if_missing' in processors:
-        return
-
-    error_message = ' '.join((
-        "TEMPLATE_CONTEXT_PROCESSORS does not contain add_page_if_missing.",
-        "FeinCMSLoginRequiredMiddleware requires the FeinCMS page middleware",
-        "to be installed. Ensure your TEMPLATE_CONTEXT_PROCESSORS setting",
-        "includes 'feincms.context_processors.add_page_if_missing'.",
-    ))
-    raise ImproperlyConfigured(error_message)
+from .permission import LoginPermissionMiddlewareMixin
+from .permission_feincms import FeinCMSPermissionMiddleware
 
 
 class FeinCMSLoginRequiredMiddleware(
@@ -35,6 +13,3 @@ class FeinCMSLoginRequiredMiddleware(
     Requires authentication middleware, template context processors, and FeinCMS's
     add_page_if_missing middleware to be loaded. You'll get an error if they aren't.
     """
-    def __init__(self, check=True):
-        if check:
-            check_feincms_page()

--- a/incuna_auth/middleware/permission.py
+++ b/incuna_auth/middleware/permission.py
@@ -3,7 +3,6 @@ from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.utils.translation import ugettext_lazy as _
 
 from .utils import compile_urls
-from ..models import AccessStateExtensionMixin as AccessState
 
 
 ALL_URLS = compile_urls([r'^'])
@@ -164,66 +163,3 @@ class UrlPermissionMiddleware(BasePermissionMiddleware):
             return True
 
         return False
-
-
-class FeinCMSPermissionMiddleware(BasePermissionMiddleware):
-    """
-    Middleware that allows or denies access based on the resource's access state.
-
-    Access state is provided by incuna_auth.models.AccessStateExtensionMixin and is used
-    as a marker to determine how a FeinCMS resource should be access-controlled.
-
-    The reasoning behind this is twofold. FeinCMS resources have unpredictable URLs, so
-    protecting them with the URL-based middleware is risky. Additionally, a client might
-    want to add a variety of permissions on their Pages (or similar) that don't
-    necessarily correspond to their location within the site. Adding an access_state
-    and checking that through middleware allows maximum flexibility and puts permissions
-    on the page level fully within the user's control.
-
-    This class protects all pages with an access_state of STATE_AUTH_ONLY. To protect
-    a different state or list of states, override get_protected_states.
-    """
-    def get_protected_states(self):
-        """
-        Returns a list of access states this middleware should apply to.
-
-        By default, returns STATE_AUTH_ONLY, which is the only non-custom access state
-        that implies any restriction.
-        """
-        return [AccessState.STATE_AUTH_ONLY]
-
-    def _get_resource_access_state(self, request):
-        """
-        Returns the FeinCMS resource's access_state, following any INHERITed values.
-
-        Will return None if the resource has an access state that should never be
-        protected. It should not be possible to protect a resource with an access_state
-        of STATE_ALL_ALLOWED, or an access_state of STATE_INHERIT and no parent.
-        """
-        feincms_page = getattr(request, 'feincms_page')
-
-        # Chase inherited values up the tree of inheritance.
-        INHERIT = AccessState.STATE_INHERIT
-        while feincms_page.access_state == INHERIT and hasattr(feincms_page, 'parent'):
-            feincms_page = feincms_page.parent
-
-        # Resources with STATE_ALL_ALLOWED or STATE_INHERIT and no parent should never be
-        # access-restricted. This code is here rather than in is_resource_protected to
-        # emphasise its importance and help avoid accidentally overriding it.
-        never_restricted = (INHERIT, AccessState.STATE_ALL_ALLOWED)
-        if feincms_page.access_state in never_restricted:
-            return None
-
-        # Return the found value.
-        return feincms_page.access_state
-
-    def is_resource_protected(self, request, **kwargs):
-        """
-        Determines if a resource should be protected.
-
-        Returns true if and only if the resource's access_state matches an entry in
-        the return value of get_protected_states().
-        """
-        access_state = self._get_resource_access_state(request)
-        protected_states = self.get_protected_states()
-        return access_state in protected_states

--- a/incuna_auth/middleware/permission_feincms.py
+++ b/incuna_auth/middleware/permission_feincms.py
@@ -1,0 +1,74 @@
+from .permission import BasePermissionMiddleware
+from ..models import AccessStateExtensionMixin as AccessState
+
+
+class FeinCMSPermissionMiddleware(BasePermissionMiddleware):
+    """
+    Middleware that allows or denies access based on the resource's access state.
+
+    Access state is provided by incuna_auth.models.AccessStateExtensionMixin and is used
+    as a marker to determine how a FeinCMS resource should be access-controlled.
+
+    The reasoning behind this is twofold. FeinCMS resources have unpredictable URLs, so
+    protecting them with the URL-based middleware is risky. Additionally, a client might
+    want to add a variety of permissions on their Pages (or similar) that don't
+    necessarily correspond to their location within the site. Adding an access_state
+    and checking that through middleware allows maximum flexibility and puts permissions
+    on the page level fully within the user's control.
+
+    This class protects all pages with an access_state of STATE_AUTH_ONLY. To protect
+    a different state or list of states, override get_protected_states.
+    """
+    def get_protected_states(self):
+        """
+        Returns a list of access states this middleware should apply to.
+
+        By default, returns STATE_AUTH_ONLY, which is the only non-custom access state
+        that implies any restriction.
+        """
+        return [AccessState.STATE_AUTH_ONLY]
+
+    def _get_page_from_path(self, path):
+        """
+        Fetches the FeinCMS Page object that the path points to.
+
+        Override this to deal with different types of object from Page.
+        """
+        from feincms.module.page.models import Page
+        return Page.objects.best_match_for_path(path)
+
+    def _get_resource_access_state(self, request):
+        """
+        Returns the FeinCMS resource's access_state, following any INHERITed values.
+
+        Will return None if the resource has an access state that should never be
+        protected. It should not be possible to protect a resource with an access_state
+        of STATE_ALL_ALLOWED, or an access_state of STATE_INHERIT and no parent.
+        """
+        feincms_page = self._get_page_from_path(request.path_info.lstrip('/'))
+
+        # Chase inherited values up the tree of inheritance.
+        INHERIT = AccessState.STATE_INHERIT
+        while feincms_page.access_state == INHERIT and hasattr(feincms_page, 'parent'):
+            feincms_page = feincms_page.parent
+
+        # Resources with STATE_ALL_ALLOWED or STATE_INHERIT and no parent should never be
+        # access-restricted. This code is here rather than in is_resource_protected to
+        # emphasise its importance and help avoid accidentally overriding it.
+        never_restricted = (INHERIT, AccessState.STATE_ALL_ALLOWED)
+        if feincms_page.access_state in never_restricted:
+            return None
+
+        # Return the found value.
+        return feincms_page.access_state
+
+    def is_resource_protected(self, request, **kwargs):
+        """
+        Determines if a resource should be protected.
+
+        Returns true if and only if the resource's access_state matches an entry in
+        the return value of get_protected_states().
+        """
+        access_state = self._get_resource_access_state(request)
+        protected_states = self.get_protected_states()
+        return access_state in protected_states

--- a/tests/test_middleware_checks.py
+++ b/tests/test_middleware_checks.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from incuna_auth.middleware import FeinCMSLoginRequiredMiddleware, LoginRequiredMiddleware
+from incuna_auth.middleware import LoginRequiredMiddleware
 
 
 class TestCheckRequestHasUser(TestCase):
@@ -21,27 +21,6 @@ class TestCheckRequestHasUser(TestCase):
             "LoginRequiredMiddleware requires authentication middleware to be",
             "installed. Ensure that your MIDDLEWARE_CLASSES setting includes",
             "'django.contrib.auth.middleware.AuthenticationMiddleware'.",
-        ))
-        with self.assertRaisesRegexp(ImproperlyConfigured, expected_error):
-            self.middleware()
-
-
-class TestCheckFeinCMSPage(TestCase):
-    middleware = FeinCMSLoginRequiredMiddleware
-    requirement = 'feincms.context_processors.add_page_if_missing'
-
-    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=[requirement])
-    def test_check_passes(self):
-        """Assert that no error is thrown by __init__."""
-        self.middleware()
-
-    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=[])
-    def test_check_fails(self):
-        expected_error = ' '.join((
-            "TEMPLATE_CONTEXT_PROCESSORS does not contain add_page_if_missing.",
-            "FeinCMSLoginRequiredMiddleware requires the FeinCMS page middleware",
-            "to be installed. Ensure your TEMPLATE_CONTEXT_PROCESSORS setting",
-            "includes 'feincms.context_processors.add_page_if_missing'.",
         ))
         with self.assertRaisesRegexp(ImproperlyConfigured, expected_error):
             self.middleware()

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -2,7 +2,6 @@ import mock
 
 from incuna_auth.middleware import permission
 from incuna_auth.middleware.utils import compile_urls
-from incuna_auth.models import AccessStateExtensionMixin as AccessState
 from .utils import RequestTestCase
 
 
@@ -143,90 +142,4 @@ class TestUrlPermissionMiddleware(RequestTestCase):
         request = self.make_request()
         method = self.middleware_path.format('get_protected_url_patterns')
         with mock.patch(method, return_value=[]):
-            self.assertFalse(self.middleware.is_resource_protected(request))
-
-
-class TestFeinCMSPermissionMiddleware(RequestTestCase):
-    middleware_class = permission.FeinCMSPermissionMiddleware
-    middleware_path = 'incuna_auth.middleware.permission.FeinCMSPermissionMiddleware.{}'
-    CUSTOM_STATE = ('custom', 'Custom state')
-
-    class DummyFeinCMSPage:
-        def __init__(self, access_state):
-            self.access_state = access_state
-
-    def setUp(self):
-        self.middleware = self.middleware_class()
-
-    def make_request(self, access_state=CUSTOM_STATE, **kwargs):
-        """Create a request with a suitable feincms_page attribute."""
-        request = self.create_request(**kwargs)
-        request.feincms_page = self.DummyFeinCMSPage(access_state=access_state)
-        return request
-
-    def test_get_protected_states(self):
-        """Assert the default return value of this method."""
-        expected_states = [AccessState.STATE_AUTH_ONLY]
-        self.assertEqual(expected_states, self.middleware.get_protected_states())
-
-    def test_get_resource_access_state(self):
-        """Assert that the correct access_state value comes back from the request."""
-        expected_state = self.CUSTOM_STATE
-        request = self.make_request()
-        self.assertEqual(
-            expected_state,
-            self.middleware._get_resource_access_state(request)
-        )
-
-    def test_get_resource_access_state_unrestricted(self):
-        """
-        Assert that the certain access_state values are never restricted.
-
-        STATE_INHERIT is only unrestricted when the resource has no parent; the
-        behaviour of STATE_INHERIT on a resource *with* a parent is tested elsewhere, so
-        both cases are covered.
-        """
-        unrestricted_states = (AccessState.STATE_INHERIT, AccessState.STATE_ALL_ALLOWED)
-        request = self.make_request()
-        for state in unrestricted_states:
-            request.feincms_page.access_state = state
-            self.assertIsNone(self.middleware._get_resource_access_state(request))
-
-    def test_get_resource_access_state_failure(self):
-        """Assert that the method explodes when the request has no feincms_page."""
-        request = self.create_request()  # Lacks feincms_page attribute
-        with self.assertRaises(AttributeError):
-            self.middleware._get_resource_access_state(request)
-
-    def test_get_resource_access_state_inherited(self):
-        """Assert that the method deals correctly with inherited access_state values."""
-        parent_page = self.DummyFeinCMSPage(self.CUSTOM_STATE)
-        request = self.make_request(access_state=AccessState.STATE_INHERIT)
-        request.feincms_page.parent = parent_page
-
-        expected_state = self.CUSTOM_STATE
-        self.assertEqual(
-            expected_state,
-            self.middleware._get_resource_access_state(request)
-        )
-
-    def test_resource_protected(self):
-        """
-        Assert that the URL is protected when the value of get_protected_states contains
-        feincms_page.access_state.
-        """
-        request = self.make_request()
-        method = self.middleware_path.format('get_protected_states')
-        with mock.patch(method, return_value=[self.CUSTOM_STATE]):
-            self.assertTrue(self.middleware.is_resource_protected(request))
-
-    def test_resource_unprotected(self):
-        """
-        Assert that the URL is not protected when the value of get_protected_states
-        doesn't contain feincms_page.access_state.
-        """
-        request = self.make_request()
-        method = self.middleware_path.format('get_protected_states')
-        state = ('other-state', 'Other State')
-        with mock.patch(method, return_value=[state]):
             self.assertFalse(self.middleware.is_resource_protected(request))

--- a/tests/test_permission_feincms.py
+++ b/tests/test_permission_feincms.py
@@ -1,0 +1,93 @@
+import mock
+
+from incuna_auth.middleware import permission_feincms
+from incuna_auth.models import AccessStateExtensionMixin as AccessState
+from .utils import RequestTestCase
+
+
+class TestFeinCMSPermissionMiddleware(RequestTestCase):
+    middleware_class = permission_feincms.FeinCMSPermissionMiddleware
+    middleware_path = (
+        'incuna_auth.middleware.permission_feincms.' +
+        'FeinCMSPermissionMiddleware.{}'
+    )
+    get_page_method = middleware_path.format('_get_page_from_path')
+
+    CUSTOM_STATE = ('custom', 'Custom state')
+
+    class DummyFeinCMSPage:
+        def __init__(self, access_state):
+            self.access_state = access_state
+
+    def setUp(self):
+        self.middleware = self.middleware_class()
+
+    def make_request(self, access_state=CUSTOM_STATE, **kwargs):
+        """Create a request with a suitable feincms_page attribute."""
+        request = self.create_request(**kwargs)
+        request.feincms_page = self.DummyFeinCMSPage(access_state=access_state)
+        return request
+
+    def test_get_protected_states(self):
+        """Assert the default return value of this method."""
+        expected_states = [AccessState.STATE_AUTH_ONLY]
+        self.assertEqual(expected_states, self.middleware.get_protected_states())
+
+    def test_get_resource_access_state(self):
+        """Assert that the correct access_state value comes back from the request."""
+        request = self.make_request()
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            access_state = self.middleware._get_resource_access_state(request)
+
+        expected_state = self.CUSTOM_STATE
+        self.assertEqual(expected_state, access_state)
+
+    def test_get_resource_access_state_unrestricted(self):
+        """
+        Assert that the certain access_state values are never restricted.
+
+        STATE_INHERIT is only unrestricted when the resource has no parent; the
+        behaviour of STATE_INHERIT on a resource *with* a parent is tested elsewhere, so
+        both cases are covered.
+        """
+        unrestricted_states = (AccessState.STATE_INHERIT, AccessState.STATE_ALL_ALLOWED)
+        request = self.make_request()
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            for state in unrestricted_states:
+                request.feincms_page.access_state = state
+                self.assertIsNone(self.middleware._get_resource_access_state(request))
+
+    def test_get_resource_access_state_inherited(self):
+        """Assert that the method deals correctly with inherited access_state values."""
+        parent_page = self.DummyFeinCMSPage(self.CUSTOM_STATE)
+        request = self.make_request(access_state=AccessState.STATE_INHERIT)
+        request.feincms_page.parent = parent_page
+
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            access_state = self.middleware._get_resource_access_state(request)
+
+        expected_state = self.CUSTOM_STATE
+        self.assertEqual(expected_state, access_state)
+
+    def test_resource_protected(self):
+        """
+        Assert that the URL is protected when the value of get_protected_states contains
+        feincms_page.access_state.
+        """
+        request = self.make_request()
+        get_states_method = self.middleware_path.format('get_protected_states')
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            with mock.patch(get_states_method, return_value=[self.CUSTOM_STATE]):
+                self.assertTrue(self.middleware.is_resource_protected(request))
+
+    def test_resource_unprotected(self):
+        """
+        Assert that the URL is not protected when the value of get_protected_states
+        doesn't contain feincms_page.access_state.
+        """
+        request = self.make_request()
+        get_states_method = self.middleware_path.format('get_protected_states')
+        state = ('other-state', 'Other State')
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            with mock.patch(get_states_method, return_value=[state]):
+                self.assertFalse(self.middleware.is_resource_protected(request))


### PR DESCRIPTION
It turns out that using the FeinCMS template context processor to add feincms_page to the request doesn't work - we actually have to import FeinCMS and use Page.objects.best_match_for_path() to get the Page object (and its access state).

This is pretty ugly, so nicer solutions would be appreciated if anyone has any...

@incuna/backend review please?