### PR TITLE
Don't crash if feincms_page is missing

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Upcoming
+--------
+* Bugfix: Don't fail when the FeinCMS Page object doesn't exist at the named URL.
+
 v2.3.2
 --------
 * Bugfix: Access FeinCMS pages properly.

--- a/incuna_auth/middleware/permission_feincms.py
+++ b/incuna_auth/middleware/permission_feincms.py
@@ -44,8 +44,12 @@ class FeinCMSPermissionMiddleware(BasePermissionMiddleware):
         Will return None if the resource has an access state that should never be
         protected. It should not be possible to protect a resource with an access_state
         of STATE_ALL_ALLOWED, or an access_state of STATE_INHERIT and no parent.
+
+        Will also return None if the accessed URL doesn't contain a Page.
         """
         feincms_page = self._get_page_from_path(request.path_info.lstrip('/'))
+        if not feincms_page:
+            return None
 
         # Chase inherited values up the tree of inheritance.
         INHERIT = AccessState.STATE_INHERIT

--- a/tests/test_permission_feincms.py
+++ b/tests/test_permission_feincms.py
@@ -42,6 +42,14 @@ class TestFeinCMSPermissionMiddleware(RequestTestCase):
         expected_state = self.CUSTOM_STATE
         self.assertEqual(expected_state, access_state)
 
+    def test_get_resource_access_state_no_page(self):
+        """Assert that the access_state is None when feincms_page is None."""
+        request = self.make_request()
+        with mock.patch(self.get_page_method, return_value=None):
+            access_state = self.middleware._get_resource_access_state(request)
+
+        self.assertIsNone(access_state)
+
     def test_get_resource_access_state_unrestricted(self):
         """
         Assert that the certain access_state values are never restricted.


### PR DESCRIPTION
With the new way of looking for feincms_page, we can no longer depend on it being there.

@incuna/backend quick review please? :)