### PR TITLE
Deal with pages having null parents

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Upcoming
+--------
+* Bugfix: Don't fail when the FeinCMS Page object has a parent, but that parent is None.
+
 v2.3.3
 --------
 * Bugfix: Don't fail when the FeinCMS Page object doesn't exist at the named URL.

--- a/incuna_auth/middleware/permission_feincms.py
+++ b/incuna_auth/middleware/permission_feincms.py
@@ -53,10 +53,7 @@ class FeinCMSPermissionMiddleware(BasePermissionMiddleware):
 
         # Chase inherited values up the tree of inheritance.
         INHERIT = AccessState.STATE_INHERIT
-        while (
-            feincms_page.access_state == INHERIT and
-            getattr(feincms_page, 'parent', None)
-        ):
+        while feincms_page.access_state == INHERIT and feincms_page.parent:
             feincms_page = feincms_page.parent
 
         # Resources with STATE_ALL_ALLOWED or STATE_INHERIT and no parent should never be

--- a/incuna_auth/middleware/permission_feincms.py
+++ b/incuna_auth/middleware/permission_feincms.py
@@ -53,7 +53,10 @@ class FeinCMSPermissionMiddleware(BasePermissionMiddleware):
 
         # Chase inherited values up the tree of inheritance.
         INHERIT = AccessState.STATE_INHERIT
-        while feincms_page.access_state == INHERIT and hasattr(feincms_page, 'parent'):
+        while (
+            feincms_page.access_state == INHERIT and
+            getattr(feincms_page, 'parent', None)
+        ):
             feincms_page = feincms_page.parent
 
         # Resources with STATE_ALL_ALLOWED or STATE_INHERIT and no parent should never be

--- a/tests/test_permission_feincms.py
+++ b/tests/test_permission_feincms.py
@@ -77,6 +77,18 @@ class TestFeinCMSPermissionMiddleware(RequestTestCase):
         expected_state = self.CUSTOM_STATE
         self.assertEqual(expected_state, access_state)
 
+    def test_get_resource_access_state_null_parent(self):
+        """
+        Assert that the method doesn't explode when the Page has a parent which is None.
+        """
+        request = self.make_request(access_state=AccessState.STATE_INHERIT)
+        request.feincms_page.parent = None
+
+        with mock.patch(self.get_page_method, return_value=request.feincms_page):
+            access_state = self.middleware._get_resource_access_state(request)
+
+        self.assertIsNone(access_state)
+
     def test_resource_protected(self):
         """
         Assert that the URL is protected when the value of get_protected_states contains

--- a/tests/test_permission_feincms.py
+++ b/tests/test_permission_feincms.py
@@ -63,6 +63,7 @@ class TestFeinCMSPermissionMiddleware(RequestTestCase):
         with mock.patch(self.get_page_method, return_value=request.feincms_page):
             for state in unrestricted_states:
                 request.feincms_page.access_state = state
+                request.feincms_page.parent = None
                 self.assertIsNone(self.middleware._get_resource_access_state(request))
 
     def test_get_resource_access_state_inherited(self):


### PR DESCRIPTION
`hasattr(feincms_page, 'parent')` isn't good enough; the Page can have a parent which is None, causing crashes.

@incuna/backend another quick review please?