### PR TITLE
Support Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
+  - 3.5
   - 3.4
-  - 3.3
   - 2.7
 script: make test
 notifications:
@@ -12,12 +12,10 @@ env:
   matrix:
     - DJANGO='django>=1.6,<1.7'
     - DJANGO='django>=1.7,<1.8'
-matrix:
-  exclude:
-     - env: DJANGO='django>=1.4,<1.5'
-       python: 3.3
-     - env: DJANGO='django>=1.4,<1.5'
-       python: 3.4
+    - DJANGO='django>=1.8,<1.9'
+    - DJANGO='django>=1.9,<1.10'
+    - DJANGO='django>=1.10,<1.11'
+    - DJANGO='django>=1.11,<1.12'
 install:
   - psql -c 'CREATE DATABASE incuna_auth' -U postgres;
   - pip install $DJANGO

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
+  - 3.6
   - 3.5
-  - 3.4
   - 2.7
 script: make test
 notifications:
@@ -16,6 +16,17 @@ env:
     - DJANGO='django>=1.9,<1.10'
     - DJANGO='django>=1.10,<1.11'
     - DJANGO='django>=1.11,<1.12'
+exclude:
+  matrix:
+    - env: DJANGO='django>=1.6,<1.7'
+      python: 3.5
+    - env: DJANGO='django>=1.7,<1.8'
+      python: 3.5
+    - env: DJANGO='django>=1.6,<1.7'
+      python: 3.6
+    - env: DJANGO='django>=1.7,<1.8'
+      python: 3.6
+
 install:
   - psql -c 'CREATE DATABASE incuna_auth' -U postgres;
   - pip install $DJANGO

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - DJANGO='django>=1.9,<1.10'
     - DJANGO='django>=1.10,<1.11'
     - DJANGO='django>=1.11,<1.12'
-exclude:
-  matrix:
+matrix:
+  exclude:
     - env: DJANGO='django>=1.6,<1.7'
       python: 3.5
     - env: DJANGO='django>=1.7,<1.8'

--- a/changelog.rst
+++ b/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 * Support up to Django 1.11.
 * Drop support for Django 1.4 and earlier.
+* Drop support for Python 3.3 and 3.4. The library will probably continue to work, but
+  we're no longer actively checking the functionality.
 
 7.4.0
 -----

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+8.0.0
+-----
+
+* Support up to Django 1.11.
+* Drop support for Django 1.4 and earlier.
+
 7.4.0
 -----
 

--- a/incuna_auth/templates/registration/base/login_form_base.html
+++ b/incuna_auth/templates/registration/base/login_form_base.html
@@ -1,6 +1,5 @@
 {% load crispy_forms_tags %}
 {% load i18n %}
-{% load url from future %}
 
 
 {% block content %}

--- a/incuna_auth/templates/registration/base/password_change_done_base.html
+++ b/incuna_auth/templates/registration/base/password_change_done_base.html
@@ -1,7 +1,6 @@
 {% extends "registration/base.html" %}
 
 {% load i18n %}
-{% load url from future %}
 
 
 {% block title %}{% trans "Password Change Successful" %}{% endblock title %}

--- a/incuna_auth/templates/registration/base/password_change_form_base.html
+++ b/incuna_auth/templates/registration/base/password_change_form_base.html
@@ -2,7 +2,6 @@
 
 {% load crispy_forms_tags %}
 {% load i18n %}
-{% load url from future %}
 
 
 {% block title %}{% trans "Password Change" %}{% endblock title %}

--- a/incuna_auth/templates/registration/base/password_reset_confirm_base.html
+++ b/incuna_auth/templates/registration/base/password_reset_confirm_base.html
@@ -2,7 +2,6 @@
 
 {% load crispy_forms_tags %}
 {% load i18n %}
-{% load url from future %}
 
 
 {% block title %}

--- a/incuna_auth/templates/registration/base/password_reset_email_base.html
+++ b/incuna_auth/templates/registration/base/password_reset_email_base.html
@@ -1,6 +1,5 @@
 {% spaceless %}
 {% load i18n %}
-{% load url from future %}
 
 
 {% autoescape off %}

--- a/incuna_auth/tests/test_middleware.py
+++ b/incuna_auth/tests/test_middleware.py
@@ -4,8 +4,8 @@ from unittest import TestCase
 
 import mock
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
-from django.urls import reverse
 
 from incuna_auth.middleware import (
     basic_auth,

--- a/incuna_auth/tests/test_middleware.py
+++ b/incuna_auth/tests/test_middleware.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 import mock
 from django.conf import settings
 from django.test.utils import override_settings
+from django.urls import reverse
 
 from incuna_auth.middleware import (
     basic_auth,
@@ -27,6 +28,7 @@ class TestLoginRequiredMiddleware(RequestTestCase):
     middleware = LoginRequiredMiddleware(check=False)
     EXEMPT_URLS = 'incuna_auth.middleware.LoginRequiredMiddleware.EXEMPT_URLS'
     PROTECTED_URLS = 'incuna_auth.middleware.LoginRequiredMiddleware.PROTECTED_URLS'
+    login = reverse(settings.LOGIN_URL)
 
     def make_request(self, auth, method='get', url='/fake-request/', **kwargs):
         return self.create_request(method, auth=auth, url=url, **kwargs)
@@ -57,7 +59,7 @@ class TestLoginRequiredMiddleware(RequestTestCase):
         request = self.make_request(auth=False)
         response = self.middleware.process_request(request)
         message = 'You must be logged in to view this page.'
-        redirect_url = settings.LOGIN_URL + '?next=/fake-request/'
+        redirect_url = self.login + '?next=/fake-request/'
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['location'], redirect_url)
@@ -69,7 +71,7 @@ class TestLoginRequiredMiddleware(RequestTestCase):
     def test_non_auth_get_script_name(self):
         request = self.make_request(auth=False)
         response = self.middleware.process_request(request)
-        redirect_url = settings.LOGIN_URL + '?next=/base/script/path/fake-request/'
+        redirect_url = self.login + '?next=/base/script/path/fake-request/'
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['location'], redirect_url)
@@ -86,6 +88,7 @@ class TestFeinCMSLoginRequiredMiddleware(RequestTestCase):
     middleware = FeinCMSLoginRequiredMiddleware()
     AUTH_STATE = AccessState.STATE_AUTH_ONLY
     OTHER_STATE = ('other', 'Other state')
+    login = reverse(settings.LOGIN_URL)
 
     get_page_method = (
         'incuna_auth.middleware.permission_feincms.' +
@@ -128,7 +131,7 @@ class TestFeinCMSLoginRequiredMiddleware(RequestTestCase):
         with mock.patch(self.get_page_method, return_value=request.feincms_page):
             response = self.middleware.process_request(request)
         message = 'You must be logged in to view this page.'
-        redirect_url = settings.LOGIN_URL + '?next=/'
+        redirect_url = self.login + '?next=/'
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response['location'], redirect_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 colour-runner==0.0.4
 coverage==3.7.1
 django-admin-sso==0.1.3
-django-crispy-forms==1.4.0
+django-crispy-forms==1.6.1
 django-discover-runner==1.0
 dj-database-url==0.3.0
 factory-boy==2.4.1

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = ('django-admin-sso', 'django-crispy-forms')
 
 setup(
     name='incuna-auth',
-    version='7.4.0',
+    version='8.0.0',
     url='http://github.com/incuna/incuna-auth',
     packages=find_packages(),
     include_package_data=True,

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -18,6 +18,10 @@ DATABASES = {
 }
 DEFAULT_FILE_STORAGE = 'inmemorystorage.InMemoryStorage'
 
+LOGIN_URL = 'login'
+LOGOUT_URL = 'logout'
+LOGIN_REDIRECT_URL = 'logout'
+
 INSTALLED_APPS = (
     'incuna_auth',
     'incuna_auth.tests',


### PR DESCRIPTION
I was getting a `TemplateSyntaxError: future is not a tag library`. Removing the `{% load url from future %}` lines drops support for Django 1.4 and earlier, which doesn't seem exactly problematic :P

@incuna/backend review please?